### PR TITLE
chore: remove print(e) from FastAPI (server) /generate endpoint and m…

### DIFF
--- a/fifo_tool_airlock_model_env/server/fastapi_server.py
+++ b/fifo_tool_airlock_model_env/server/fastapi_server.py
@@ -53,11 +53,7 @@ async def generate(request: InferenceRequestContainerized):
                 content=f"Unrecognized model '{request.model}'"
             )
 
-        try:
-            output = model.generate(request)
-        except Exception as e:
-            print(e)
-            raise e
+        output = model.generate(request)
 
         return Response(content=output, media_type="text/plain")
 

--- a/fifo_tool_airlock_model_env/server/llm_model.py
+++ b/fifo_tool_airlock_model_env/server/llm_model.py
@@ -1,5 +1,9 @@
 from abc import ABC, abstractmethod
+import logging
 from fifo_tool_airlock_model_env.common.models import InferenceRequestContainerized
+
+
+logger = logging.getLogger(__name__)
 
 class LLMModel(ABC):
     """
@@ -20,14 +24,14 @@ class LLMModel(ABC):
         """
         raise NotImplementedError
 
-    def _print_token_stats(self,
+    def _log_token_stats(self,
                            model_name: str,
                            adapter_name: str | None,
                            input_tokens: int,
                            output_tokens: int,
                            duration: float):
         """
-        Print input/output token counts and generation time duration for a given model/adapter.
+        Log input/output token counts and generation time duration for a given model/adapter.
 
         Args:
             model_name (str):
@@ -46,5 +50,5 @@ class LLMModel(ABC):
                 Time in seconds taken to generate the response.
         """
         adapter = "[base model]" if adapter_name is None else f"[{adapter_name}]"
-        print(f"📥 {input_tokens:>4} tokens in   ➜   📤 {output_tokens:>4} "
-              f"tokens out   ⏱️ {duration:.2f}s    📦 {model_name}{adapter}")
+        logger.info("📥 %4d tokens in   ➜   📤 %4d tokens out   ⏱️ %.2fs    📦 %s%s",
+                    input_tokens, output_tokens, duration, model_name, adapter)

--- a/fifo_tool_airlock_model_env/server/llm_model_phi_4_base_with_adapters.py
+++ b/fifo_tool_airlock_model_env/server/llm_model_phi_4_base_with_adapters.py
@@ -266,7 +266,7 @@ class LLMModelPhi4WithAdapters(LLMModel, Generic[TTokenizerOrProcessor]):
         output_ids = output_ids[:, input_token_count:]
         output_token_count = output_ids.shape[1]
         response = self._decode_output(output_ids)
-        self._print_token_stats(
+        self._log_token_stats(
             self._model_path, request.adapter, input_token_count, output_token_count, duration
         )
         return response


### PR DESCRIPTION
## Summary

- In the FastAPI (server) `/generate` endpoint:
  - Remove `print(e)`
  - Rely on `logger.exception()` for error logging (static message only, no exception details), as already in place.
- Rename `_print_token_stats` to `_log_token_stats` and use `logger.info()` instead of `print`, for consistent logging.

## Why

- Clean up logging and centralize all logs via structured log handling.
- Simplify error handling by removing redundant `try/except`.
- Improve code readability and maintain consistency.

## Notes

- No functional changes.